### PR TITLE
Ilmen tooltip escape html

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       return toa.normalize('NFD')
                 .replace(/i/g, 'ı')
                 .replace(/[\u0300-\u030f]/g, '')
-                .replace(/[^0-9A-Za-zı'_-]+/g, ' ')
+                .replace(/[^0-9A-Za-zı'_\-]+/g, ' ')
                 .replace(/ +/g, ' ')
                 .trim()
                 .toLowerCase();

--- a/index.html
+++ b/index.html
@@ -46,6 +46,26 @@
   </script>
   <script>
     /*** AUTOMATIC WORD DEFINITION TOOLTIPS FOR TOAQ TEXTS ***/
+    
+    function with_escaped_html(text) {
+      return text.replace(/[&<>"']/g, function(ch) {
+        switch (ch) {
+          case '&':
+            return '&amp;';
+          case '<':
+            return '&lt;';
+          case '>':
+            return '&gt;';
+          case '"':
+            return '&quot;';
+          default:
+            return '&#039;';
+            /* '&apos;' in another option in HTML5, but is absent from
+               HTML4. */
+        }
+      });
+    };
+    
     function normalized(toa) {
       return toa.normalize('NFD')
                 .replace(/i/g, 'ı')
@@ -55,6 +75,7 @@
                 .trim()
                 .toLowerCase();
     }
+    
     $.getJSON(
       "https://toaq.github.io/dictionary/dictionary.json",
       function(dict) {
@@ -81,10 +102,11 @@
                 if (normalized(entry.toaq) == normalized_word) {
                   // We have found the word in the dictionary.
                   // Now we create a tooltip containing its definition:
+                  var def = with_escaped_html(entry.english)
+                            .replace(/▯/g, "___");
                   array[index] = '<div class="tip">' + item
                         + '<span class="tiptext">' + normalized_word
-                        + ' : ' + entry.english.replace(/▯/g, "___")
-                        + '</span></div>';
+                        + ' : ' + def + '</span></div>';
                 }
                 /* If we don't find the word in the dictionary, no tooltip
                    is created. Nothing will happen when hovering the word


### PR DESCRIPTION
index.html: Adding an HTML escape function to the definition tooltip script; this fixes the security issue whereby people with write access to dictionary.json could insert HTML and Javascript code within the definition of a word and by this mean modify the code of the toaq.org front page, as before this commit the content of word definitions was loaded without checking whether there were HTML code within them.